### PR TITLE
Fix #82: ResponseBuilder doesn't clear properly

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,9 +2,9 @@ name: build and test
 
 on:
   push:
-    branches: [ master, Rel* ]
+    branches: [ main, Rel* ]
   pull_request:
-    branches: [ master, Rel* ]
+    branches: [ main, Rel* ]
 
 jobs:
   build:

--- a/CyborgianStates.Tests/MessageHandling/ResponseBuilderTests.cs
+++ b/CyborgianStates.Tests/MessageHandling/ResponseBuilderTests.cs
@@ -61,5 +61,50 @@ namespace CyborgianStates.Tests.MessageHandling
             response.ResponseObject.Should().NotBeNull();
             response.ResponseObject.Should().BeAssignableTo<Embed>();
         }
+
+        [Fact]
+        public void DiscordResponseBuilder_Clear_Successfully()
+        {
+            var builder = new DiscordResponseBuilder()
+               .Failed("Reason")
+               .WithTitle("Title")
+               .WithThumbnailUrl("https://localhost/image.jpg")
+               .WithDescription("Description")
+               .WithDefaults("Footer")
+               .WithField("Key1", "Value")
+               .WithContent("BlaBla")
+               .WithUrl("https://localhost");
+            var response = builder.Build();
+            response.Status.Should().Be(CommandStatus.Error);
+            response.Content.Should().Be("BlaBla");
+            response.ResponseObject.Should().NotBeNull();
+            response.ResponseObject.Should().BeAssignableTo<Embed>();
+            builder.Clear();
+            response = builder.Build();
+            response.ResponseObject.Should().BeNull();
+            response.Status.Should().Be(CommandStatus.Success);
+            response.Content.Should().BeNull();
+        }
+
+        [Fact]
+        public void ConsoleResponseBuilder_Clear_Successfully()
+        {
+            var builder = new ConsoleResponseBuilder()
+               .Failed("Reason")
+               .WithTitle("Title")
+               .WithThumbnailUrl("https://localhost/image.jpg")
+               .WithDescription("Description")
+               .WithDefaults("Footer")
+               .WithField("Key1", "Value")
+               .WithContent("BlaBla")
+               .WithUrl("https://localhost");
+            var response = builder.Build();
+            response.Status.Should().Be(CommandStatus.Error);
+            response.Content.Should().Contain("BlaBla");
+            builder.Clear();
+            response = builder.Build();
+            response.Status.Should().Be(CommandStatus.Success);
+            response.Content.Should().BeEmpty();
+        }
     }
 }

--- a/CyborgianStates/MessageHandling/BaseResponseBuilder.cs
+++ b/CyborgianStates/MessageHandling/BaseResponseBuilder.cs
@@ -11,7 +11,7 @@ namespace CyborgianStates.MessageHandling
 {
     public abstract class BaseResponseBuilder : IResponseBuilder
     {
-        protected readonly CommandResponse _response;
+        protected CommandResponse _response;
         protected readonly Dictionary<FieldKey, string> _properties = new();
         protected readonly Dictionary<string, (string, bool)> _fields = new();
 
@@ -62,6 +62,7 @@ namespace CyborgianStates.MessageHandling
         {
             _properties.Clear();
             _fields.Clear();
+            _response = new();
         }
     }
 }

--- a/CyborgianStates/MessageHandling/Discord/DiscordResponseBuilder.cs
+++ b/CyborgianStates/MessageHandling/Discord/DiscordResponseBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using CyborgianStates.CommandHandling;
 using CyborgianStates.Enums;
 using Discord;
@@ -7,45 +8,46 @@ namespace CyborgianStates.MessageHandling
 {
     public class DiscordResponseBuilder : BaseResponseBuilder
     {
-        private readonly EmbedBuilder _builder;
-        public DiscordResponseBuilder() : base()
-        {
-            _builder = new EmbedBuilder();
-        }
         public override CommandResponse Build()
         {
+            var builder = new EmbedBuilder();
             if (_properties.ContainsKey(FieldKey.Url))
             {
-                _builder.WithUrl(_properties[FieldKey.Url]);
+                builder.WithUrl(_properties[FieldKey.Url]);
             }
             if (_properties.ContainsKey(FieldKey.Title))
             {
-                _builder.WithTitle(_properties[FieldKey.Title]);
+                builder.WithTitle(_properties[FieldKey.Title]);
             }
             if (_properties.ContainsKey(FieldKey.Description))
             {
-                _builder.WithDescription(_properties[FieldKey.Description]);
+                builder.WithDescription(_properties[FieldKey.Description]);
             }
             foreach (var field in _fields)
             {
                 var value = field.Value.Item1;
                 var isInline = field.Value.Item2;
                 var fieldName = field.Key;
-                _builder.AddField(fieldName, value, isInline);
+                builder.AddField(fieldName, value, isInline);
             }
             if (_properties.ContainsKey(FieldKey.Footer))
             {
-                _builder.WithFooter(_properties[FieldKey.Footer]);
+                builder.WithFooter(_properties[FieldKey.Footer]);
             }
             if (_properties.ContainsKey(FieldKey.ThumbnailUrl))
             {
-                _builder.WithThumbnailUrl(_properties[FieldKey.ThumbnailUrl]);
+                builder.WithThumbnailUrl(_properties[FieldKey.ThumbnailUrl]);
             }
             if (_properties.ContainsKey(FieldKey.Color))
             {
-                _builder.WithColor(Convert.ToUInt32(_properties[FieldKey.Color][1..], 16));
+                builder.WithColor(Convert.ToUInt32(_properties[FieldKey.Color][1..], 16));
             }
-            return new CommandResponse(_response.Status, _response.Content) { ResponseObject = _builder.Build() };
+            var embed = builder.Build();
+            if(!_fields.Any() && !_properties.Any())
+            {
+                embed = null;
+            }
+            return new CommandResponse(_response.Status, _response.Content) { ResponseObject = embed };
         }
     }
 }


### PR DESCRIPTION
## Description

Ensure that ResponseBuilder (especially DiscordResponseBuilder) gets cleared properly when Clear() gets called.



## Motivation and Context

Fixes #82 


## How Has This Been Tested?

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.

- [x] I have added tests to cover my changes.

- [x] All new and existing tests passed.



